### PR TITLE
Add multiple key options to authn sequence

### DIFF
--- a/src/chef_authn.erl
+++ b/src/chef_authn.erl
@@ -482,8 +482,8 @@ verify_sigs(Plain, BodyHash, ContentHash, AuthSig, UserId, [{KeyId, PubKey} | Re
         {name, UserId} = verify_sig(Plain, BodyHash, ContentHash, AuthSig, UserId, PubKey, SignVersion),
         {name, UserId, KeyId}
     catch
-        %% We can fail for other reasons than signature not being right; most of those aren't badmatch though.
-        error:{badmatch, _} -> verify_sigs(Plain, BodyHash, ContentHash, AuthSig, UserId, Remaining, SignVersion)
+        error:_Any ->
+            verify_sigs(Plain, BodyHash, ContentHash, AuthSig, UserId, Remaining, SignVersion)
     end.
 
 -spec verify_sig(binary(), binary(), binary(), binary(), binary(),


### PR DESCRIPTION
To support key rotation we would like to try to auth against a list of
keys and return the first key that succeeds. This extends the
authenticate_user_request API to accept a list of {key_description,
public_key} pairs and returns {name, user, and key_description} if one
matches.

@sdelano @marcparadise @tylercloke 